### PR TITLE
TODOが残ってるとrails sが通らない問題への対処

### DIFF
--- a/ruffnote_api.gemspec
+++ b/ruffnote_api.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = RuffnoteApi::VERSION
   spec.authors       = ["pandeiro245"]
   spec.email         = ["nishiko@mindia.jp"]
-  spec.description   = %q{TODO: Write a gem description}
-  spec.summary       = %q{TODO: Write a gem summary}
+  spec.description   = %q{https://ruffnote.com/apidoc}
+  spec.summary       = %q{https://ruffnote.com/apidoc}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
```
kawakami@fzdv:shikaku-rails[marge_parse]$ rails s
The gemspec at /Users/kawakami/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bundler/gems/ruffnote_api-02614a03ce37/ruffnote_api.gemspec is not valid. The validation error was '"FIXME" or "TODO" is not a description'
```

こうなるのでTODO表記を変更していただけると開発し易いです・・・
